### PR TITLE
using shared library for better compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.10)
 
 project(npystream LANGUAGES CXX VERSION 0.1.0)
 
-add_library(npystream "src/npystream.cpp"
+add_library(npystream SHARED "src/npystream.cpp"
   "include/npystream/npystream.hpp"
   "include/npystream/map_type.hpp"
   "include/npystream/tuple_util.hpp"


### PR DESCRIPTION
I'd love to using shared library instead of static library(default) for using this library with cling and ROOT(cern).
test no problem using shared library